### PR TITLE
socketcand.conf: fix port number default value

### DIFF
--- a/etc/socketcand.conf
+++ b/etc/socketcand.conf
@@ -2,7 +2,7 @@
 # listen = "eth0";
 
 # The port the socketcand is listening on
-# port = 28600;
+# port = 29536;
 
 # List of busses the daemon shall provide access to
 # Multiple busses must be separated with ',' and whitespace


### PR DESCRIPTION
This fixes the default port number value in the config file