### PR TITLE
Disable libconfig by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_ARG_ENABLE(init_script, [  --disable-init-script Enable creation of init.d st
               AC_SUBST(init_script, "no"), AC_SUBST(init_script, "yes"))
 
 # Checks for libconfig.
-AC_ARG_WITH([config], [AS_HELP_STRING([--without-config], [do not use libconfig])], [], [with_config=yes])
+AC_ARG_WITH([config], [AS_HELP_STRING([--with-config], [use libconfig])], [], [with_config=no])
 
 LIBCONFIG=
           AS_IF([test "x$with_config" != xno],


### PR DESCRIPTION
Reverse the logic so that libconfig must be explicitly enabled
via --with-config.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>