### PR TITLE
Fix GCC10 build failure

### DIFF
--- a/socketcand.c
+++ b/socketcand.c
@@ -102,7 +102,6 @@ socklen_t unaddrlen;
 struct sockaddr_un remote_unaddr;
 socklen_t remote_unaddrlen;
 char* interface_string;
-struct ifreq ifr, ifr_brd;
 
 int state_changed(char *buf, int current_state)
 {
@@ -666,6 +665,8 @@ int receive_command(int socket, char *buffer) {
 }
 
 void determine_adress() {
+	struct ifreq ifr, ifr_brd;
+
 	int probe_socket = socket(AF_INET, SOCK_DGRAM, 0);
 
 	if(probe_socket < 0) {

--- a/state_bcm.c
+++ b/state_bcm.c
@@ -28,8 +28,6 @@
 #define RXLEN 128
 
 int sc = -1;
-fd_set readfds;
-struct timeval tv;
 
 void state_bcm() {
 	int i, j, ret;
@@ -38,6 +36,7 @@ void state_bcm() {
 	struct ifreq ifr;
 	char rxmsg[RXLEN];
 	char buf[MAXLEN];
+	fd_set readfds;
 
 	struct {
 		struct bcm_msg_head msg_head;
@@ -91,6 +90,7 @@ void state_bcm() {
 	}
 
 	if (FD_ISSET(sc, &readfds)) {
+		struct timeval tv;
 
 		ret = recvfrom(sc, &msg, sizeof(msg), 0,
 			       (struct sockaddr*)&caddr, &caddrlen);

--- a/state_isotp.c
+++ b/state_isotp.c
@@ -25,7 +25,6 @@
 #include <linux/sockios.h>
 
 int si = -1;
-fd_set readfds;
 
 void state_isotp() {
 	int i, items, ret;
@@ -39,6 +38,7 @@ void state_isotp() {
 	char buf[MAXLEN]; /* inet commands to can */
 	unsigned char isobuf[ISOTPLEN+1]; /* binary buffer for isotp socket */
 	unsigned char tmp;
+	fd_set readfds;
 	
 	while(previous_state != STATE_ISOTP) {
 

--- a/state_raw.c
+++ b/state_raw.c
@@ -25,7 +25,6 @@
 int raw_socket;
 struct ifreq ifr;
 struct sockaddr_can addr;
-fd_set readfds;
 struct msghdr msg;
 struct can_frame frame;
 struct iovec iov;
@@ -36,6 +35,7 @@ struct cmsghdr *cmsg;
 void state_raw() {
 	char buf[MAXLEN];
 	int i, ret, items;
+	fd_set readfds;
 
 	if(previous_state != STATE_RAW) {
 


### PR DESCRIPTION
GCC10 breaks on multiple definitions:

ld: /tmp/ccFiGYO7.o:(.bss+0x114): multiple definition of `tv'; /tmp/cc7f6J5h.o:(.bss+0x80): first defined here

Change the scope of the related variables.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>