### PR TITLE
Add RTR frames to TCP messages

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -74,6 +74,22 @@ Send a single CAN frame without cyclic transmission
     // ID: 1AAAAAAA, Length: 2, Data: 0x01 0xF1
     < send 1AAAAAAA 2 1 F1 > 
 
+#### Send a single Remote-transfer-request frame ####
+This command is used to send a single RTR CAN frame.
+
+    < sendrtr can_id can_dlc >
+
+Example:
+Send a single CAN frame without cyclic transmission
+
+    // ID: 123, DLC 0
+    < sendrtr 123 0 > 
+    
+    // ID: 1AAAAAAA, DLC 2
+    < sendrtr 1AAAAAAA 2 > 
+
+Note that DLC may cause collisions on CAN bus. Check CiA application note 802
+
 ### Commands for reception ###
 The commands for reception are 'subscribe' , 'unsubscribe' and 'filter'.
 
@@ -169,7 +185,16 @@ Example:
 Reception of a CAN frame with CAN ID 0x123 , data length 4 and data 0x11, 0x22, 0x33 and 0x44 at time 23.424242>
 
     < frame 123 23.424242 11 22 33 44 >
+    
+#### RTR frame transmission ####
+CAN RTR messages received in raw mode:
+    < rtr can_id seconds.useconds can_dlc >
 
+Example:
+Reception of a RTR frame with CAN ID 0x123 , data length 4 at time 23.424242
+
+    < rtr 123 23.424242 4 >
+    
 #### Switch to BCM mode ####
 With '< bcmmode >' it is possible to switch back to BCM mode.
 

--- a/doc/raspberrypi.md
+++ b/doc/raspberrypi.md
@@ -2,7 +2,7 @@ Running on Raspberry PI
 ===================
 
 For this example used adapter-board: https://www.waveshare.com/rs485-can-hat.htm you can find it on aliexpress too.
-After flashing Raspberry image to SD card modify 'config.txt', uncomment this like:
+After flashing Raspberry image to SD card modify 'config.txt', uncomment this line:
 
 	dtparam=spi=on
 

--- a/socketcandcl.c
+++ b/socketcandcl.c
@@ -344,9 +344,8 @@ inline void state_connected()
 				}
 				if (!strncmp("< rtr ", buf, 6)) {
 					//send RTR frame only
-					sscanf(buf, "< %*s %x %*d.%*d >", &frame.can_id);
-					//force DLC 0 since it is undocumented feature
-					frame.can_dlc = 0;
+					sscanf(buf, "< %*s %x %*d.%*d %hhu >", &frame.can_id, &frame.can_dlc);
+
 					frame.can_id |= CAN_RTR_FLAG;
 					char *s = buf + 6;
 					for (; ++s;) {
@@ -392,21 +391,19 @@ inline void state_connected()
 				} else {
 					if(frame.can_id & CAN_ERR_FLAG) {
 						/* TODO implement */
-					} else if(frame.can_id & CAN_RTR_FLAG) {
-						/* TODO implement */
 					} else {
 						if (frame.can_id & CAN_RTR_FLAG) {
 							if (frame.can_id & CAN_EFF_FLAG) {
-								ret = sprintf(buf, "< sendrtr %08X >", frame.can_id & CAN_EFF_MASK);
+								ret = sprintf(buf, "< sendrtr %08X %hhu >", frame.can_id & CAN_EFF_MASK, frame.can_dlc);
 							} else {
-								ret = sprintf(buf, "< sendrtr %03X >", frame.can_id & CAN_SFF_MASK);
+								ret = sprintf(buf, "< sendrtr %03X %hhu >", frame.can_id & CAN_SFF_MASK, frame.can_dlc);
 							}
 						} else {
 							int i;
 							if (frame.can_id & CAN_EFF_FLAG) {
-								ret = sprintf(buf, "< send %08X %d ", frame.can_id & CAN_EFF_MASK, frame.can_dlc);
+								ret = sprintf(buf, "< send %08X %hhu ", frame.can_id & CAN_EFF_MASK, frame.can_dlc);
 							} else {
-								ret = sprintf(buf, "< send %03X %d ", frame.can_id & CAN_SFF_MASK, frame.can_dlc);
+								ret = sprintf(buf, "< send %03X %hhu ", frame.can_id & CAN_SFF_MASK, frame.can_dlc);
 							}
 							for (i = 0; i < frame.can_dlc; i++) {
 								ret += sprintf(buf + ret, "%02x ", frame.data[i]);

--- a/state_bcm.c
+++ b/state_bcm.c
@@ -198,13 +198,12 @@ void state_bcm() {
 			/* Add a send job */
 		} else if (!strncmp("< sendrtr ", buf, 10)) {
 			//send RTR frame only
-			items = sscanf(buf, "< %*s %x >", &msg.msg_head.can_id);
-			if ((items < 1)) {
-				PRINT_ERROR("Syntax error in send command\n")
+			items = sscanf(buf, "< %*s %x %hhu >", &msg.msg_head.can_id, &msg.frame.can_dlc);
+			if ((items < 2) || (msg.frame.can_dlc > CAN_MAX_DLEN)) {
+				PRINT_ERROR("Syntax error in sendrtr command\n")
 				return;
 			}
-			//force DLC 0 since it is undocumented feature
-			msg.frame.can_dlc = 0;
+
 			msg.msg_head.can_id |= CAN_RTR_FLAG;
 
 			if (element_length(buf, 2) == 8)

--- a/state_raw.c
+++ b/state_raw.c
@@ -122,9 +122,9 @@ void state_raw() {
 				send(client_socket, buf, strlen(buf), 0);
 			} else if (frame.can_id & CAN_RTR_FLAG) {
 				if (frame.can_id & CAN_EFF_FLAG) {
-					ret = sprintf(buf, "< rtr %08X %ld.%06ld >", frame.can_id & CAN_EFF_MASK, tv.tv_sec, tv.tv_usec);
+					ret = sprintf(buf, "< rtr %08X %ld.%06ld %hhu >", frame.can_id & CAN_EFF_MASK, tv.tv_sec, tv.tv_usec, frame.can_dlc);
 				} else {
-					ret = sprintf(buf, "< rtr %03X %ld.%06ld >", frame.can_id & CAN_SFF_MASK, tv.tv_sec, tv.tv_usec);
+					ret = sprintf(buf, "< rtr %03X %ld.%06ld %hhu >", frame.can_id & CAN_SFF_MASK, tv.tv_sec, tv.tv_usec, frame.can_dlc);
 				}
 				send(client_socket, buf, strlen(buf), 0);
 			} else {
@@ -194,13 +194,12 @@ void state_raw() {
 
 			} else if (!strncmp("< sendrtr ", buf, 10)) {
 				//send RTR frame only
-				items = sscanf(buf, "< %*s %x >", &frame.can_id);
-				if ((items < 1)) {
-					PRINT_ERROR("Syntax error in send command\n")
+				items = sscanf(buf, "< %*s %x %hhu >", &frame.can_id, &frame.can_dlc);
+				if ((items < 2) || (frame.can_dlc > CAN_MAX_DLEN)) {
+					PRINT_ERROR("Syntax error in sendrtr command\n")
 					return;
 				}
-				//force DLC 0 since it is undocumented feature
-				frame.can_dlc = 0;
+
 				frame.can_id |= CAN_RTR_FLAG;
 
 				if (element_length(buf, 2) == 8)


### PR DESCRIPTION
added < rtr %x %d.%d> message for received Remote transfer request messages in raw mode
added < sendrtr %x > to send RTR message
a little bit formatted files with eclipse CDT formatter

p.s. code needs optimisation... remove same used parts of code, make something like can_message_decode/encode to parse text. Too much same used code. 

p.p.s. barely tested. However raspberry pi successfully sends rtr messages over tcp