### PR TITLE
Add support for CAN interfaces configurations based on libsocketcan

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ To build and run socketcand make sure you have the following tools installed:
 * a kernel that includes the SocketCAN modules
 * the headers for your kernel version
 * the libconfig with headers (libconfig-dev under debian based systems)
+* the libsocketcan with headers (libsocketcan-dev under debian based systems) is a requirement to configure the interfaces from socketcand
 
 Execute the following commands to configure, build, and install the software:
 

--- a/canctl.c
+++ b/canctl.c
@@ -1,0 +1,88 @@
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libsocketcan.h>
+
+int canctl_set_bittiming(const char *bus_name, const char *buff_bittiming_conf, int buff_length)
+{
+	int bitrate, sample_point, tq, prop_seg, phase_seg1, phase_seg2, sjw, brp, items;
+
+	items = sscanf(buff_bittiming_conf, "< %*s B %d %d %d %d %d %d %d %d >", 
+		&bitrate, 
+		&sample_point,
+		&tq, 
+		&prop_seg,
+		&phase_seg1,
+		&phase_seg2, 
+		&sjw,
+		&brp
+	);
+
+	if (items != 8)	{
+		return -1;
+	}
+
+	struct can_bittiming bt;
+	memset(&bt, 0, sizeof(bt));
+	if (bitrate >= 0) {
+		bt.bitrate = bitrate;
+	}
+
+	if (sample_point >= 0) {
+		bt.sample_point = sample_point;
+	}
+
+	if (tq >= 0) {
+		bt.tq = tq;
+	}
+
+	if (prop_seg >= 0) {
+		bt.prop_seg = prop_seg;
+	}
+
+	if (phase_seg1 >= 0) {
+		bt.phase_seg1 = phase_seg1;
+	}
+
+	if (phase_seg2 >= 0) {
+		bt.phase_seg2 = phase_seg2;
+	}
+	
+	if (sjw >= 0) {
+		bt.sjw = sjw;
+	}
+
+	if (brp >= 0) {
+		bt.brp = brp;
+	}
+
+	return !(can_do_stop(bus_name) || can_set_bittiming(bus_name, &bt)) ? 0 : -1;
+}
+
+int canctl_set_control_modes(const char *bus_name, const char *buff_control_modes_conf, int buff_length)
+{
+	int listen_only, loopback, three_samples, items;
+
+	items = sscanf(buff_control_modes_conf, "< %*s C %d %d %d >", 
+		&listen_only, &loopback, &three_samples);
+
+	if (items != 3) {
+		return -1;
+	}
+
+	struct can_ctrlmode cm = {
+		.mask = CAN_CTRLMODE_LISTENONLY | CAN_CTRLMODE_LOOPBACK | CAN_CTRLMODE_3_SAMPLES,
+	};
+
+	if (listen_only)
+		cm.flags |= CAN_CTRLMODE_LISTENONLY;
+	if (loopback)
+		cm.flags |= CAN_CTRLMODE_LOOPBACK;
+	if (three_samples)
+		cm.flags |= CAN_CTRLMODE_3_SAMPLES;
+	
+	return !(can_do_stop(bus_name) || can_set_ctrlmode(bus_name, &cm)) ? 0 : -1;
+}

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -11,15 +11,17 @@ After connecting to the socket the client is greeted with '< hi >'. The open com
 where canbus may be at maximum 16 characters long. If the client is allowed to access the bus the server will respond with '< ok >'. Otherwise an error is returned and the connection is terminated.
 After a bus was opened the mode is switched to BCM mode. The Mode NO_BUS is the only mode where bittimings or other bus configuration settings may be done.
 
-#### Configure the bittiming (to be implemented) ####
+#### Configure the bittiming ####
 The protocol enables the client to change the bittiming of a given bus as provided by set link. Automatic bitrate configuration by the kernel is not supported because it is not guaranteed that the corresponding option was enabled during compile time (e.g. in Ubuntu 10.10 it is not). This way it it also easier to implement the function in a microcontroller based adapter.
 
     < can0 B bitrate sample_point tq prop_seg phase_seg1 phase_seg2 sjw brp >
 
-#### Set the controlmode (to be implementend) ####
+#### Set the controlmode ####
 The control mode controls if the bus is set to listen only, if sent packages are looped back and if the controller is configured to take three samples. The following command provides access to these settings. Each field must be set to '0' or '1' to disable or enable the setting.
 
     < can0 C listen_only loopback three_samples >
+
+**_NOTE:_** The interface configuration only works if socketcand is compiled with libsocketcan dependency.
 
 ## Mode BCM (default mode) ##
 After the client has successfully opened a bus the mode is switched to BCM mode (DEFAULT). In this mode a BCM socket to the bus will be opened and can be controlled over the connection. The following commands are understood:

--- a/include/linux/canctl.h
+++ b/include/linux/canctl.h
@@ -1,0 +1,69 @@
+/**
+ * canctrl.h
+ * 
+ * Functions to configure the CAN interfaces (bitrates, control modes, etc...)
+ */
+
+
+#ifndef __CANCTRL_H__
+#define __CANCTRL_H__
+
+#ifdef HAVE_LIBSOCKETCAN
+
+#include <libsocketcan.h>
+
+/**
+ * canctl_set_bittiming - Set the interface bittiming.
+ * 
+ * @param bus_name name of the can interface to configure.
+ * @param buff_bittiming_conf buffer which contains the remaining config of the interface.
+ * @param buff_length config buffer length.
+ * 
+ * returns 0 - ok / -1 error
+ */
+int canctl_set_bittiming(const char *bus_name, const char *buff_bittiming_conf, int buff_length);
+
+/**
+ * canctl_start_iface - Start the can interface.
+ * 
+ * @param bus_name name of the can interface to start.
+ * 
+ * returns 0 - ok / -1 error
+ */
+static inline int canctl_start_iface(const char *bus_name)
+{
+	return can_do_start(bus_name);
+}
+
+/**
+ * canctl_set_control_modes - set up control modes for given interface.
+ * 
+ * @param bus_name name of the can interface to configure.
+ * @param buff_control_modes_conf buffer which contains the control modes configuration.
+ * @param buff_length config buffer length.
+ * 
+ * returns 0 - ok / -1 error
+ */
+int canctl_set_control_modes(const char *bus_name, const char *buff_control_modes_conf, int buff_length);
+
+#else
+
+#include <errno.h>
+
+static inline int canctl_set_bittiming(const char *bus_name, const char *buff_bittiming_conf, int buff_length)
+{
+	return -EINVAL;
+}
+
+static inline int canctl_start_iface(const char *bus_name)
+{
+	return 0;
+}
+
+static inline int canctl_set_control_modes(const char *bus_name, const char *buff_control_modes_conf, int buff_length)
+{
+    return -EINVAL;
+}
+
+#endif
+#endif

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,17 @@ deps = [dependency('threads')]
 enable_rc_script = get_option('rc_script')
 enable_init_script = get_option('init_script')
 
+src =  [
+    'socketcand.c',
+    'statistics.c',
+    'beacon.c',
+    'state_bcm.c',
+    'state_raw.c',
+    'state_isotp.c',
+    'state_control.c',
+    'state_nobus.c',
+]
+
 # Check if libconfig is available
 enable_libconfig = get_option('libconfig')
 if enable_libconfig
@@ -16,16 +27,16 @@ if enable_libconfig
     endif
 endif
 
+# Check if libsocketcan is available
+dep_libsocketcan = dependency('libsocketcan', required: false)
+if dep_libsocketcan.found()
+    conf.set_quoted('HAVE_LIBSOCKETCAN', '1')
+    deps += dep_libsocketcan
+    src += 'canctl.c'
+endif
+
 executable('socketcand',
-    [
-        'socketcand.c',
-        'statistics.c',
-        'beacon.c',
-        'state_bcm.c',
-        'state_raw.c',
-        'state_isotp.c',
-        'state_control.c',
-    ],
+    src,
     include_directories : include_directories('include'),
     dependencies: deps,
     install : true,

--- a/socketcand.h
+++ b/socketcand.h
@@ -36,6 +36,7 @@ void state_raw();
 void state_isotp();
 void state_control();
 void tcp_quickack();
+void state_nobus();
 
 extern int client_socket;
 extern char **interface_names;

--- a/state_nobus.c
+++ b/state_nobus.c
@@ -1,0 +1,104 @@
+#include "config.h"
+#include "socketcand.h"
+#include "include/linux/canctl.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+
+static int check_bus(const char *bus_name) 
+{
+	int found = 0, i;
+
+	for (i = 0; i < interface_count; i++) {
+		if (!strcmp(interface_names[i], bus_name))
+			found = 1;
+	}
+	return found;
+}
+
+void state_nobus(void)
+{
+	int i;
+	char buf[MAXLEN], op;
+
+	if (previous_state != STATE_NO_BUS) {
+		strcpy(buf, "< hi >");
+		send(client_socket, buf, strlen(buf), 0);
+		tcp_quickack(client_socket);
+		previous_state = STATE_NO_BUS;
+	}
+
+	/* client has to start with a command */
+	i = receive_command(client_socket, buf);
+	if (i != 0) {
+		PRINT_ERROR("Connection terminated while waiting for command.\n");
+		state = STATE_SHUTDOWN;
+		return;
+	}
+
+	if (!strncmp("< open ", buf, 7)) {
+		sscanf(buf, "< open %s>", bus_name);
+
+		/* check if access to this bus is allowed */
+		if (!check_bus(bus_name)) {
+			PRINT_INFO("client tried to access unauthorized bus.\n");
+			strcpy(buf, "< error could not open bus >");
+			goto shutdown_err;
+		} 
+		if (canctl_start_iface (bus_name)) {
+			PRINT_INFO("Error starting CAN interface.\n");
+			snprintf(buf, MAXLEN, "< error could not start interface %s >", bus_name);
+			goto shutdown_err;
+		}
+		state = STATE_BCM;
+		goto return_ok;
+	} else if (sscanf(buf, "< %s %c ", bus_name, &op) == 2) {
+		/* check if access to this bus is allowed */
+		if (!check_bus(bus_name)) {
+			PRINT_INFO("client tried to access unauthorized bus.\n");
+			strcpy(buf, "< error could not open bus >");
+			goto shutdown_err;
+		} 
+
+		/* Check the configuration operation */
+		switch (op) {
+			case 'B':
+				if (canctl_set_bittiming(bus_name, buf, strlen(buf))) {
+					PRINT_ERROR("Error configuring bus bittiming.\n");
+					snprintf(buf, MAXLEN, "< error configuring interface %s > \n", bus_name);
+					goto shutdown_err;
+				}
+				break;
+			case 'C':
+				if (canctl_set_control_modes(bus_name, buf, strlen(buf))) {
+					PRINT_ERROR("Error configuring bus control modes.\n");
+					snprintf(buf, MAXLEN, "< error configuring interface %s > \n", bus_name);
+					goto shutdown_err;
+				}
+				break;
+			default:
+				PRINT_ERROR("Configuration operation not supported\n");
+				snprintf(buf, MAXLEN, "< configuration operation not supported %c > \n", op);
+				goto shutdown_err;
+				break;
+		}
+
+		goto return_ok;
+	} else {
+		PRINT_ERROR("unknown command '%s'.\n", buf);
+		strcpy(buf, "< error unknown command >");
+		send(client_socket, buf, strlen(buf), 0);
+		tcp_quickack(client_socket);
+	}
+
+return_ok:
+	strcpy(buf, "< ok >");
+	send(client_socket, buf, strlen(buf), 0);
+	tcp_quickack(client_socket);
+	return;
+shutdown_err:
+	send(client_socket, buf, strlen(buf), 0);
+	tcp_quickack(client_socket);
+	state = STATE_SHUTDOWN;
+} 


### PR DESCRIPTION
#  Summary 

This is a PR proposal to implement the CAN interfaces configurations using libsocketcan. In order to do that, the following changes were performed:

- Refactor in the nobus state, as far as all the logic there is running out of control in the main file (socketcand.c) and to follow the same rationale used for the other states (the state function implemented in a sepparated file / function) 
- Adding of canctl.c file to implement the functions to perform the interfaces configuration.
- Adding the libsocketcan reference / dependency in the autotools.
- If the libsocketcan dependency check fails, the library will implement mock functions or errors (depending on the function) 

# Test

Tested with a custom gs_usb dongle based on STM32G0 and candlelight firmware. The tests were performed in ubuntu 22.04:

``` sudo ./socketcand -i can0```

Test the client using telnet in other terminal: 

```telnet localhost 29536```

Then, we can perform a basic config of the interface:

```
< hi >< can0 B 500000 -1 -1 -1 -1 -1 -1 -1 >
< ok >< can0 C 1 1 0 >
< ok >< open can0 >
```

As soon as the <open>  command is executed, the interface starts to work and we have the following config available in the system:

```7: can0: <NOARP,UP,LOWER_UP,ECHO> mtu 16 qdisc pfifo_fast state UP mode DEFAULT group default qlen 10
    link/can  promiscuity 0 minmtu 0 maxmtu 0 
    can <LOOPBACK> state ERROR-ACTIVE restart-ms 0 
	  bitrate 500000 sample-point 0.875 
	  tq 25 prop-seg 34 phase-seg1 35 phase-seg2 10 sjw 5
	  gs_usb: tseg1 1..256 tseg2 1..128 sjw 1..128 brp 1..512 brp-inc 1
	  termination 0 [ 0, 120 ]
	  clock 40000000 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 parentbus usb parentdev 3-1.1.2:1.0 
```
Now if we filter and send, we can see the device working in loopback mode:

```
< filter 0 0 123 1 FF >
< send 123 0 >
< frame 123 1732634826.235033  >
```