### PR TITLE
meson: install socketcand binary to the sbin directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,8 @@ executable('socketcand',
     ],
     include_directories : include_directories('include'),
     dependencies: deps,
-    install : true
+    install : true,
+    install_dir : get_option('sbindir')
 )
 
 executable('socketcandcl',


### PR DESCRIPTION
Move `socketcand` daemon binary to the system executable directory as it usually done for the service daemons.