### PR TITLE
Fix configuration header for canctrl.h file

### DIFF
--- a/src/canctl.c
+++ b/src/canctl.c
@@ -3,8 +3,6 @@
  * SPDX-FileCopyrightText: 2024 Jesus Jorge Serrano <jesusjorgeserrano@geotab.com>
  */
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/canctl.h
+++ b/src/canctl.h
@@ -12,6 +12,8 @@
 #ifndef __CANCTRL_H__
 #define __CANCTRL_H__
 
+#include "config.h"
+
 #ifdef HAVE_LIBSOCKETCAN
 
 #include <libsocketcan.h>


### PR DESCRIPTION
# Summary

During some tests, I noticed a regression in the canctrl.h file which is not including the config.h file added in the PR #35 

I don't know if this is a regression added later or if it is wrong since the beggining ( I recall to test it) but, anyway, it is necessary to make the configuration to work using libsocketcan.
