### PR TITLE
Allow interface renaming on the socketcand protocol side

### DIFF
--- a/src/beacon.c
+++ b/src/beacon.c
@@ -54,7 +54,7 @@ void *beacon_loop(void *ptr)
 			}
 			chars_left = BEACON_LENGTH - n;
 
-			snprintf(buffer + (n * sizeof(char)), chars_left, "<Bus name=\"%s\"/>", interface_names[i]);
+			snprintf(buffer + (n * sizeof(char)), chars_left, "<Bus name=\"%s\"/>", bus_names[i]);
 		}
 
 		/* Find \0 in beacon buffer */

--- a/src/socketcand.c
+++ b/src/socketcand.c
@@ -656,7 +656,7 @@ void print_usage(void)
 	printf("Usage: socketcand [-v | --verbose] [-i interfaces | --interfaces interfaces]\n\t\t[-p port | --port port] [-q | --quick-ack]\n\t\t[-l interface | --listen interface] [-u name | --afuxname name]\n\t\t[-n | --no-beacon] [-d | --daemon] [-h | --help]\n\n");
 	printf("Options:\n");
 	printf("\t-v (activates verbose output to STDOUT)\n");
-	printf("\t-i <interfaces> (comma separated list of SocketCAN interfaces the daemon\n\t\tshall provide access to e.g. '-i can0,vcan1' - default: %s)\n", DEFAULT_BUSNAME);
+	printf("\t-i <interfaces>[=<bus>] (comma separated list of SocketCAN interfaces the daemon\n\t\tshall provide access to e.g. '-i can0,vcan1'\n\t\tmight include an optional bus name,\n\t\tif different from interface e.g. '-i vcan0=mybus' - default: %s)\n", DEFAULT_BUSNAME);
 	printf("\t-p <port> (changes the default port '%d' the daemon is listening at)\n", PORT);
 	printf("\t-q (enable TCP_QUICKACK socket option)\n");
 	printf("\t-l <interface> (changes the default network interface the daemon will\n\t\tbind to - default: %s)\n", DEFAULT_INTERFACE);

--- a/src/socketcand.c
+++ b/src/socketcand.c
@@ -50,6 +50,7 @@ int receive_command(int socket, char *buf);
 int sl, client_socket;
 pthread_t beacon_thread, statistics_thread;
 char **interface_names;
+char **bus_names;
 int interface_count = 0;
 int port;
 int verbose_flag = 0;
@@ -298,6 +299,16 @@ int main(int argc, char **argv)
 
 	for (i = 1; i < interface_count; i++) {
 		interface_names[i] = strtok(NULL, ",");
+	}
+
+	/* check if any of the intefaces requires a different bus name */
+	bus_names = malloc(sizeof(char *) * interface_count);
+	for (i = 0; i < interface_count; i++) {
+		strtok(interface_names[i], "="); /* split at the = if it's there */
+		bus_names[i] = strtok(NULL, "=");
+		if (bus_names[i] == NULL) {
+			bus_names[i] = interface_names[i];
+		}
 	}
 
 	/* if daemon mode was activated the syslog must be opened */

--- a/src/socketcand.h
+++ b/src/socketcand.h
@@ -56,6 +56,7 @@ void state_nobus();
 
 extern int client_socket;
 extern char **interface_names;
+extern char **bus_names;
 extern int interface_count;
 extern int port;
 extern int verbose_flag;

--- a/src/state_nobus.c
+++ b/src/state_nobus.c
@@ -8,13 +8,15 @@
 #include <string.h>
 #include <sys/socket.h>
 
-static int check_bus(const char *bus_name)
+static int check_bus(char *bus_name)
 {
 	int found = 0, i;
 
 	for (i = 0; i < interface_count; i++) {
-		if (!strcmp(interface_names[i], bus_name))
+		if (!strcmp(bus_names[i], bus_name)) {
+			strcpy(bus_name, interface_names[i]);
 			found = 1;
+		}
 	}
 	return found;
 }


### PR DESCRIPTION
### Summary
There are cases where one might want to present a "bus" (on the socketcand protocol side) which is different from the kernel CAN interface name. For example, making a remote system talk to the socketcand port the same way regardless of the USB2Can adapter on the host.
We have found such a case in a test system we are developing so we have developed this and are contributing it in case it is iseful for someone else.
### Usage
The `-i` parameter flag has been augmented, in a backwards compatible way, so now it can include a "bus name" after an equal sign, for every interface. If the "bus name" is not give, then it is equal the the interface name, to keep the current behavior.
### Example
No renaming:
```
[Terminal 1, launch socketcand]
$ ./socketcand -l lo -i vcan0
```
```
[Terminal 2, check the beacon]
$ nc -u -l 127.255.255.255 42000
<CANBeacon name="CSANC01-DEV-05" type="SocketCAN" description="socketcand">
<URL>can://127.0.0.1:29536</URL><Bus name="vcan0"/></CANBeacon>
```
```
[Terminal 3, socketcand protocol]
$ telnet localhost 29536
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
< hi >< open vcan0 >
< ok >
```

Renaming:
```
[Terminal 1, launch socketcand]
$ ./socketcand -l lo -i vcan0=mybus
```
```
[Terminal 2, check the beacon]
$ nc -u -l 127.255.255.255 42000
$ nc -u -l 127.255.255.255 42000
<CANBeacon name="CSANC01-DEV-05" type="SocketCAN" description="socketcand">
<URL>can://127.0.0.1:29536</URL><Bus name="mybus"/></CANBeacon>
```
```
[Terminal 3, socketcand protocol]
$ telnet localhost 29536
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
< hi >< open mybus >
< ok >
```


