### PR TITLE
Enable error frame reception in raw mode

### DIFF
--- a/src/socketcand.c
+++ b/src/socketcand.c
@@ -64,6 +64,7 @@ int cmd_index = 0;
 char *description;
 char *afuxname;
 int more_elements = 0;
+can_err_mask_t error_mask = 0;
 struct sockaddr_in saddr, broadcast_addr;
 struct sockaddr_un unaddr;
 socklen_t unaddrlen;
@@ -212,11 +213,12 @@ int main(int argc, char **argv)
 			{ "daemon", no_argument, 0, 'd' },
 			{ "version", no_argument, 0, 'z' },
 			{ "no-beacon", no_argument, 0, 'n' },
+			{ "error-mask", required_argument, 0, 'e' },
 			{ "help", no_argument, 0, 'h' },
 			{ 0, 0, 0, 0 }
 		};
 
-		c = getopt_long(argc, argv, "vi:p:qu:l:dznh", long_options, &option_index);
+		c = getopt_long(argc, argv, "vi:p:qu:l:dzne:h", long_options, &option_index);
 
 		if (c == -1)
 			break;
@@ -267,6 +269,10 @@ int main(int argc, char **argv)
 
 		case 'n':
 			disable_beacon = 1;
+			break;
+
+		case 'e':
+			error_mask = strtoul(optarg, NULL, 16);
 			break;
 
 		case 'h':
@@ -651,6 +657,7 @@ void print_usage(void)
 	printf("\t-l <interface> (changes the default network interface the daemon will\n\t\tbind to - default: %s)\n", DEFAULT_INTERFACE);
 	printf("\t-u <name> (the AF_UNIX socket path - abstract name when leading '/' is missing)\n\t\t(N.B. the AF_UNIX binding will supersede the port/interface settings)\n");
 	printf("\t-n (deactivates the discovery beacon)\n");
+	printf("\t-e <error_mask> (enable CAN error frames in raw mode providing an hexadecimal error mask, e.g: 0x1FFFFFFF)\n");
 	printf("\t-d (set this flag if you want log to syslog instead of STDOUT)\n");
 	printf("\t-h (prints this message)\n");
 }

--- a/src/socketcand.h
+++ b/src/socketcand.h
@@ -2,6 +2,7 @@
 
 #include <pthread.h>
 #include <syslog.h>
+#include <linux/can.h>
 
 /* max. length for ISO 15765-2 PDUs */
 #define ISOTPLEN 4095
@@ -69,6 +70,7 @@ extern pthread_t statistics_thread;
 extern int more_elements;
 extern struct sockaddr_in broadcast_addr;
 extern struct sockaddr_in saddr;
+extern can_err_mask_t error_mask;
 
 int receive_command(int socket, char *buf);
 int state_changed(char *buf, int current_state);

--- a/src/state_raw.c
+++ b/src/state_raw.c
@@ -21,6 +21,7 @@
 #include <syslog.h>
 
 #include <linux/can.h>
+#include <linux/can/raw.h>
 
 int raw_socket;
 struct ifreq ifr;
@@ -58,6 +59,13 @@ void state_raw()
 		const int timestamp_on = 1;
 		if (setsockopt(raw_socket, SOL_SOCKET, SO_TIMESTAMP, &timestamp_on, sizeof(timestamp_on)) < 0) {
 			PRINT_ERROR("Could not enable CAN timestamps\n");
+			state = STATE_SHUTDOWN;
+			return;
+		}
+
+		can_err_mask_t err_mask = CAN_ERR_MASK;
+		if (setsockopt(raw_socket, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) < 0) {
+			PRINT_ERROR("Could not enable CAN_RAW_ERR_FILTER\n");
 			state = STATE_SHUTDOWN;
 			return;
 		}

--- a/src/state_raw.c
+++ b/src/state_raw.c
@@ -63,11 +63,13 @@ void state_raw()
 			return;
 		}
 
-		can_err_mask_t err_mask = CAN_ERR_MASK;
-		if (setsockopt(raw_socket, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) < 0) {
-			PRINT_ERROR("Could not enable CAN_RAW_ERR_FILTER\n");
-			state = STATE_SHUTDOWN;
-			return;
+		if (error_mask != 0) {
+			can_err_mask_t err_mask = (error_mask & CAN_ERR_MASK);
+			if (setsockopt(raw_socket, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) < 0) {
+				PRINT_ERROR("Could not enable CAN_RAW_ERR_FILTER\n");
+				state = STATE_SHUTDOWN;
+				return;
+			}
 		}
 
 		if (bind(raw_socket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {


### PR DESCRIPTION
# Summary
I was unable to receive error frame messages in RAW mode because the code to enable error frames in the raw socket was missing (although the `CAN_ERR_FLAG` is checked for every frame). 

I have added the code to enable the error frames in the raw socket after it is created (it makes sense to do it there because in RAW mode the user expects to receive everything).

Now I do receive the error messages as expected.