### PR TITLE
always use 64-bit for timevals

### DIFF
--- a/src/state_isotp.c
+++ b/src/state_isotp.c
@@ -175,7 +175,8 @@ void state_isotp()
 		if (items > 0 && items <= ISOTPLEN) {
 			int startlen;
 
-			sprintf(rxmsg, "< pdu %ld.%06ld ", tv.tv_sec, tv.tv_usec);
+			sprintf(rxmsg, "< pdu %lld.%06lld ", (signed long long) tv.tv_sec,
+				(signed long long) tv.tv_usec);
 			startlen = strlen(rxmsg);
 
 			for (i = 0; i < items; i++)

--- a/src/state_raw.c
+++ b/src/state_raw.c
@@ -118,16 +118,19 @@ void state_raw()
 
 			if (frame.can_id & CAN_ERR_FLAG) {
 				canid_t class = frame.can_id & CAN_EFF_MASK;
-				ret = sprintf(buf, "< error %03X %ld.%06ld >", class, tv.tv_sec, tv.tv_usec);
+				ret = sprintf(buf, "< error %03X %lld.%06lld >", class,
+					      (signed long long) tv.tv_sec, (signed long long) tv.tv_usec);
 				send(client_socket, buf, strlen(buf), 0);
 				tcp_quickack(client_socket);
 			} else if (frame.can_id & CAN_RTR_FLAG) {
 				/* TODO implement */
 			} else {
 				if (frame.can_id & CAN_EFF_FLAG) {
-					ret = sprintf(buf, "< frame %08X %ld.%06ld ", frame.can_id & CAN_EFF_MASK, tv.tv_sec, tv.tv_usec);
+					ret = sprintf(buf, "< frame %08X %lld.%06lld ", frame.can_id & CAN_EFF_MASK,
+						      (signed long long) tv.tv_sec, (signed long long) tv.tv_usec);
 				} else {
-					ret = sprintf(buf, "< frame %03X %ld.%06ld ", frame.can_id & CAN_SFF_MASK, tv.tv_sec, tv.tv_usec);
+					ret = sprintf(buf, "< frame %03X %lld.%06lld ", frame.can_id & CAN_SFF_MASK,
+						      (signed long long) tv.tv_sec, (signed long long) tv.tv_usec);
 				}
 				for (i = 0; i < frame.can_dlc; i++) {
 					ret += sprintf(buf + ret, "%02X", frame.data[i]);


### PR DESCRIPTION
On 32bits platforms compiled with _TIME_BITS=64 %lu/%ld fails to print / read the timestamps correctly. Always use %llu/%lld with (un)signed long long instead. The sign follows the existing formatters, as in unsigned for reading, signed for writing.

Note: we only use the rx timestamps in raw mode and that is the only thing tested. The compiler complains about the other instances, so it is included as well.